### PR TITLE
Quote path in icon_string

### DIFF
--- a/src/open-wsl.ahk
+++ b/src/open-wsl.ahk
@@ -9,10 +9,10 @@ IniRead, use_tmux, %A_ScriptDir%\etc\wsl-terminal.conf, config, use_tmux, 0
 IniRead, attach_tmux_locally, %A_ScriptDir%\etc\wsl-terminal.conf, config, attach_tmux_locally, 0
 IniRead, icon, %A_ScriptDir%\etc\wsl-terminal.conf, config, icon, ""
 
-icon_string := "-i " A_ScriptFullPath
+icon_string = -i "%A_ScriptFullPath%"
 if (icon != "" && FileExist(icon))
 {
-    icon_string := "-i " icon
+    icon_string = -i "%icon%"
 }
 
 if (args = "-a" && WinExist(title))


### PR DESCRIPTION
I unpacked wsl-terminal 0.5 in `C:\Program Files (x86)\WSL Terminal` and got this error when I started `open-wsl.exe`:

> /usr/bin/mintty: could not load icon file 'C:\Program': The system cannot find the file specified.

So, I guess it's only natural to quote path to icon.