### PR TITLE
Feature x64

### DIFF
--- a/src/open-wsl.ahk
+++ b/src/open-wsl.ahk
@@ -9,6 +9,17 @@ IniRead, use_tmux, %A_ScriptDir%\etc\wsl-terminal.conf, config, use_tmux, 0
 IniRead, attach_tmux_locally, %A_ScriptDir%\etc\wsl-terminal.conf, config, attach_tmux_locally, 0
 IniRead, icon, %A_ScriptDir%\etc\wsl-terminal.conf, config, icon, ""
 
+bash_exe = %A_WinDir%\sysnative\bash.exe
+if (!FileExist(bash_exe))
+{
+    bash_exe = %A_WinDir%\system32\bash.exe
+}
+if (!FileExist(bash_exe))
+{
+    MsgBox, 0x10, , Ubuntu-on-Windows must be installed.
+    ExitApp, 1
+}
+
 icon_string = -i "%A_ScriptFullPath%"
 if (icon != "" && FileExist(icon))
 {
@@ -33,7 +44,7 @@ else
     if (WinExist(title))
     {
         cmd =
-        Run, c:\windows\sysnative\bash -c 'tmux new-window -c "$PWD"', , Hide
+        Run, "%bash_exe%" -c 'tmux new-window -c "$PWD"', , Hide
     }
     else if (args = "-a")
     {
@@ -90,6 +101,6 @@ else if (use_tmux)
 
     if (ErrorLevel = 0)
     {
-        Run, c:\windows\sysnative\bash -c 'exec sleep 10000000d', , Hide
+        Run, "%bash_exe%" -c 'exec sleep 10000000d', , Hide
     }
 }

--- a/src/open-wsl.ahk
+++ b/src/open-wsl.ahk
@@ -15,52 +15,52 @@ if (icon != "" && FileExist(icon))
     icon_string = -i "%icon%"
 }
 
+cmd = %shell%
+opts = -t -e SHELL="%shell%"
 if (args = "-a" && WinExist(title))
 {
-    WinActivate, %title%
+    cmd =
 }
 else if (!use_tmux)
 {
-    cmd = %shell%
     if (args = "-l")
     {
         cmd = %shell% -c "cd; %shell% -l"
     }
-
-    Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge -t %cmd%
 }
 else
 {
-    if (args = "-a" && !WinExist(title))
+    if (WinExist(title))
+    {
+        cmd =
+        Run, c:\windows\sysnative\bash -c 'tmux new-window -c "$PWD"', , Hide
+    }
+    else if (args = "-a")
     {
         if (attach_tmux_locally)
         {
-            Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge -e USE_TMUX=1 -e ATTACH_ONLY=1 -t %shell%
+            opts = %opts% -e USE_TMUX=1 -e ATTACH_ONLY=1
         }
         else
         {
-            Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge -t %shell% -c "tmux a 2>/dev/null && exit || cd && exec tmux"
+            cmd = %shell% -c "tmux a 2>/dev/null && exit || cd && exec tmux"
         }
     }
     else
     {
-        if (WinExist(title))
+        if (attach_tmux_locally)
         {
-            Run, c:\windows\sysnative\bash -c 'tmux new-window -c "$PWD"', , Hide
-            WinActivate, %title%
+            opts = %opts% -e USE_TMUX=1
         }
         else
         {
-            if (attach_tmux_locally)
-            {
-                Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge -e USE_TMUX=1 -t %shell%
-            }
-            else
-            {
-                Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge -t %shell% -c 'tmux new-window -c "$PWD" \; a 2>/dev/null || tmux'
-            }
+            cmd = %shell% -c 'tmux new-window -c "$PWD" \`; a 2>/dev/null || tmux'
         }
     }
+}
+if (cmd)
+{
+    Run, "%A_ScriptDir%\bin\mintty" %icon_string% -t "%title%" -e /bin/wslbridge %opts% %cmd%
 }
 
 Loop, 5


### PR DESCRIPTION
Work with AutoHotKey x64.
Show error, if `bash.exe` not exists.

Sorry, this PR includes #23 