### PR TITLE
Quote your vars

### DIFF
--- a/src/cmdtool
+++ b/src/cmdtool
@@ -2,7 +2,7 @@
 
 set -e
 
-cd "$(dirname $0)"
+cd "$(dirname "$0")"
 
 [[ $# == 0 || "$1" == "-h" || "$1" == "--help" ]] && {
     echo -e "Usage: $0 [OPTION]..."\

--- a/src/cmdtool
+++ b/src/cmdtool
@@ -106,19 +106,19 @@ elif [[ "$1" == "install" ]]; then
         echo OK
     elif [[ "$2" == "dash" ]]; then
         version=0.5.9.1-1
-        wget http://mirrors.ustc.edu.cn/cygwin/x86_64/release/dash/dash-$version.tar.xz 
-        tar -xvf dash-$version.tar.xz usr/bin/ash.exe
+        wget "http://mirrors.ustc.edu.cn/cygwin/x86_64/release/dash/dash-$version.tar.xz" 
+        tar -xvf "dash-$version.tar.xz" usr/bin/ash.exe
         cp -v usr/bin/ash.exe bin/dash.exe
         # mintty need a bash.exe if running with no args.
         mv -v usr/bin/ash.exe bin/bash.exe
-        rm -rf usr dash-$version.tar.xz
+        rm -rf usr "dash-$version.tar.xz"
         echo OK
     elif [[ "$2" == "busybox" ]]; then
         version=1.23.2-1
-        wget http://mirrors.ustc.edu.cn/cygwin/x86_64/release/busybox/busybox-$version.tar.xz
-        tar -xvf busybox-$version.tar.xz usr/libexec/busybox/bin/busybox.exe
+        wget "http://mirrors.ustc.edu.cn/cygwin/x86_64/release/busybox/busybox-$version.tar.xz"
+        tar -xvf "busybox-$version.tar.xz" usr/libexec/busybox/bin/busybox.exe
         mv -v usr/libexec/busybox/bin/busybox.exe bin/busybox.exe
-        rm -rf usr busybox-$version.tar.xz
+        rm -rf usr "busybox-$version.tar.xz"
         echo OK
     fi
 fi

--- a/src/cmdtool
+++ b/src/cmdtool
@@ -59,9 +59,9 @@ elif [[ "$1" == update ]]; then
     fi
 
     rm -rf wsl-terminal
-    7z x $filename || {
+    7z x "$filename" || {
         echo "$filename is broken, try again."
-        rm -v $filename
+        rm -v "$filename"
         exit 1
     }
 
@@ -74,8 +74,8 @@ elif [[ "$1" == update ]]; then
 
     cd wsl-terminal/bin
     for i in *; do
-        mv ../../bin/$i ../../bin/$i.$$.bak
-        mv -v $i ../../bin/$i
+        mv "../../bin/$i" "../../bin/$i.$$.bak"
+        mv -v "$i" "../../bin/$i"
         rm -f ../../bin/*.bak 2>/dev/null || true
     done
     cd ../..
@@ -85,7 +85,7 @@ elif [[ "$1" == update ]]; then
     mv -v wsl-terminal/{*.*,cmdtool,VERSION} .
 
     rm -rf wsl-terminal
-    rm $filename
+    rm "$filename"
     echo OK
     exit
 elif [[ "$1" == "killall" ]]; then


### PR DESCRIPTION
When trying to run `cmdtool` I was getting this weird error:

```
/mnt/b/Program Files (x86)/wsl-terminal/cmdtool: line 5: cd: /mnt/b
.
(x86)/wsl-terminal: No such file or directory
```

Quoting the usage of the path to the script fixed it.

Turns out there were several places in `cmdtool` where you use variables that might have spaces without quoting them.