### PR TITLE
Use string literals for paths in context menu entries

### DIFF
--- a/src/tools/1-add-open-wsl-terminal-here-menu.js
+++ b/src/tools/1-add-open-wsl-terminal-here-menu.js
@@ -2,10 +2,10 @@ var WshShell = new ActiveXObject("WScript.Shell");
 
 WshShell.CurrentDirectory = "..";
 WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\shell\\open-wsl\\", "Open wsl-terminal Here", "REG_SZ");
-WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\shell\\open-wsl\\Icon", WshShell.CurrentDirectory + "\\open-wsl.exe", "REG_SZ");
+WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\shell\\open-wsl\\Icon", "\"" + WshShell.CurrentDirectory + "\\open-wsl.exe\"", "REG_SZ");
 WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\shell\\open-wsl\\command\\"
-    , WshShell.CurrentDirectory + "\\open-wsl.exe -W \"%V\"", "REG_SZ");
+    , "\"" + WshShell.CurrentDirectory + "\\open-wsl.exe\" -W \"%V\"", "REG_SZ");
 WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\Background\\shell\\open-wsl\\", "Open wsl-terminal Here", "REG_SZ");
-WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\Background\\shell\\open-wsl\\Icon", WshShell.CurrentDirectory + "\\open-wsl.exe", "REG_SZ");
+WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\Background\\shell\\open-wsl\\Icon", "\"" + WshShell.CurrentDirectory + "\\open-wsl.exe\"", "REG_SZ");
 WshShell.RegWrite("HKCU\\Software\\Classes\\Directory\\Background\\shell\\open-wsl\\command\\"
-    , WshShell.CurrentDirectory + "\\open-wsl.exe", "REG_SZ");
+    , "\"" + WshShell.CurrentDirectory + "\\open-wsl.exe\"", "REG_SZ");

--- a/src/tools/5-add-open-with-vim-menu.js
+++ b/src/tools/5-add-open-with-vim-menu.js
@@ -4,6 +4,6 @@ WshShell.CurrentDirectory = "..";
 WshShell.RegWrite("HKCU\\Software\\Classes\\*\\shell\\vim-in-wsl-terminal\\"
     , "Open with &vim in wsl-terminal", "REG_SZ");
 WshShell.RegWrite("HKCU\\Software\\Classes\\*\\shell\\vim-in-wsl-terminal\\icon"
-    , WshShell.CurrentDirectory + "\\vim.exe" );
+    , "\"" + WshShell.CurrentDirectory + "\\vim.exe\"" );
 WshShell.RegWrite("HKCU\\Software\\Classes\\*\\shell\\vim-in-wsl-terminal\\command\\"
-    , WshShell.CurrentDirectory + "\\vim.exe \"%1\"", "REG_SZ");
+    , "\"" + WshShell.CurrentDirectory + "\\vim.exe\" \"%1\"", "REG_SZ");


### PR DESCRIPTION
If the path to the `open-wsl.exe` includes spaces, the context menu entries will not work properly and Windows will fail to open the executable.

This can easily be fixed by enclosing the path in string literals when writing to the registry.