### PR TITLE
fix 'cd: too many arguments' error for paths with spaces

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ emoji_support=0
 semanticVersion_reqex=".*(^[0-9]+\.[0-9]+\.[0-9]+)(-[0-9A-Za-z]+)*(_(tabbed))*$.*"
 
 scriptpath="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-cd $scriptpath
+cd "$scriptpath"
 while getopts "htv:u:" opt; do
   case ${opt} in
     h )


### PR DESCRIPTION
Encountered this error trying to install wsl-terminal into `C:\Program Files` on a Windows machine.